### PR TITLE
Fixes Windows command line usage

### DIFF
--- a/article.go
+++ b/article.go
@@ -279,5 +279,5 @@ func Input(prompt string) string {
 	if err != nil {
 		log.Fatalf("Unable to read response. %v\n", err)
 	}
-	return strings.Trim(text, "\n")
+	return strings.Trim(text, "\r\n")
 }


### PR DESCRIPTION
Windows uses CRLF line endings instead of the Unix LF, which the uploader previously didn't account for. This fixes Windows cmd input.